### PR TITLE
Remove commodity type check

### DIFF
--- a/piecash/core/transaction.py
+++ b/piecash/core/transaction.py
@@ -253,9 +253,6 @@ class Transaction(DeclarativeBaseGuid):
         if old["STATE_CHANGES"][-1] == "deleted":
             return
 
-        if self.currency.namespace != "CURRENCY":
-            raise GncValidationError("You are assigning a non currency commodity to a transaction")
-
         # check all accounts related to the splits of the transaction are not placeholder(=frozen)
         for sp in self.splits:
             if sp.account.placeholder != 0:


### PR DESCRIPTION
I see no real way to check this properly, since my German GnuCash assigns "WÄHRUNG" instead of "CURRENCY" internally…