### PR TITLE
In Transaction, tolerate a scheduled transaction or other slot being missing

### DIFF
--- a/piecash/core/transaction.py
+++ b/piecash/core/transaction.py
@@ -201,7 +201,7 @@ class Transaction(DeclarativeBaseGuid):
     description = Column('description', VARCHAR(length=2048))
     notes = pure_slot_property('notes')
 
-    scheduled_transaction = pure_slot_property('from-sched-xaction')
+    scheduled_transaction = pure_slot_property('from-sched-xaction', ignore_invalid_slot=True)
 
     # relation definitions
     currency = relation('Commodity',

--- a/piecash/kvp.py
+++ b/piecash/kvp.py
@@ -335,7 +335,7 @@ class SlotGUID(SlotFrame):
 
     @property
     def value(self):
-        return object_session(self).query(self.Class).filter_by(guid=self.guid_val).one()
+        return object_session(self).query(self.Class).filter_by(guid=self.guid_val).one_or_none()
 
     @value.setter
     def value(self, value):

--- a/piecash/kvp.py
+++ b/piecash/kvp.py
@@ -335,7 +335,7 @@ class SlotGUID(SlotFrame):
 
     @property
     def value(self):
-        return object_session(self).query(self.Class).filter_by(guid=self.guid_val).one_or_none()
+        return object_session(self).query(self.Class).filter_by(guid=self.guid_val).one()
 
     @value.setter
     def value(self, value):

--- a/piecash/sa_extra.py
+++ b/piecash/sa_extra.py
@@ -182,15 +182,11 @@ def pure_slot_property(slot_name, slot_transform=lambda x: x,
             return self[slot_name].value
         except KeyError:
             return None
-
-    if ignore_invalid_slot:
-        inner_fget = fget
-
-        def fget(self):
-            try:
-                return inner_fget(self)
-            except orm_exc.NoResultFound:
+        except orm_exc.NoResultFound:
+            if ignore_invalid_slot:
                 return None
+            else:
+                raise
 
     def fset(self, value):
         v = slot_transform(value)


### PR DESCRIPTION
The error condition is straightforward to generate:

1. Create a scheduled transaction in GnuCash
2. Use it to create a transaction
3. Delete the original template transaction
4. Open the book with piecash, and attempt to print all the transactions.

Result: an exception with a traceback that ends like this:

    ~/.virtualenvs/gnucash_importing/lib/python3.5/site-packages/piecash/sa_extra.py in fget(self)
        176         # return None if the slot does not exist. alternative could be to raise an exception
        177         try:
    --> 178             return self[slot_name].value
        179         except KeyError:
        180             return None
    
    ~/.virtualenvs/gnucash_importing/lib/python3.5/site-packages/piecash/kvp.py in value(self)
        336     @property
        337     def value(self):
    --> 338         return object_session(self).query(self.Class).filter_by(guid=self.guid_val).one()
        339 
        340     @value.setter
    
    ~/.virtualenvs/gnucash_importing/lib/python3.5/site-packages/sqlalchemy/orm/query.py in one(self)
       2818         else:
       2819             if ret is None:
    -> 2820                 raise orm_exc.NoResultFound("No row was found for one()")
       2821             return ret
       2822 

It is due to the `repr` attempting to retrieve the transaction `scheduled_transaction` property.

It can be fixed with the attached PR.

I'm happy to write a test, but I didn't know where to start. I have a minimal GnuCash sqlite file that demonstrates the problem, if that helps.