### PR TITLE
More robust lock handling; postgres db creation unique requirement

### DIFF
--- a/piecash/core/book.py
+++ b/piecash/core/book.py
@@ -273,15 +273,17 @@ class Book(DeclarativeBaseGuid):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
+    _acquire_lock = False
+
     def close(self):
         """Close a session. Any changes not yet saved are rolled back. Any lock on the file/DB is released.
         """
         session = self.session
         # cancel pending changes
         session.rollback()
-        # if self._acquire_lock:
-        # # remove the lock
-        # session.delete_lock()
+        if self._acquire_lock:
+            # remove the lock
+            session.delete_lock()
         session.close()
 
     # add general getters for gnucash classes

--- a/piecash/core/session.py
+++ b/piecash/core/session.py
@@ -29,7 +29,6 @@ gnclock = Table(u'gnclock', DeclarativeBase.metadata,
 class Version(DeclarativeBase):
     """The declarative class for the 'versions' table.
     """
-
     __tablename__ = 'versions'
 
     __table_args__ = {}


### PR DESCRIPTION
Turns on some commented out lock-related code and adds code needed to make locking work as desired under most (all?) potential lock conditions. Does not ensure unlocking if a program exits without calling book.close().

Fixes an issue where GnuCash couldn't acquire the lock on a postgresql database created by piecash because of some dumb string-encoding thing.