### PR TITLE
Avoiding duplicate protocol spec

### DIFF
--- a/piecash/core/commodity.py
+++ b/piecash/core/commodity.py
@@ -127,7 +127,7 @@ class Commodity(DeclarativeBaseGuid):
     def base_currency(self):
         b = self.book
         if b is None:
-            raise GnucashException("The commodity should be link to a session to have a 'base_currency'")
+            raise GnucashException("The commodity should be linked to a session to have a 'base_currency'")
 
         if self.namespace == "CURRENCY":
             # get the base currency as first commodity in DB

--- a/piecash/core/session.py
+++ b/piecash/core/session.py
@@ -89,7 +89,11 @@ def build_uri(sqlite_file=None,
 
     if uri_conn is None:
         if sqlite_file:
-            uri_conn = "sqlite:///{}".format(sqlite_file)
+            if sqlite_file.startswith("sqlite:///"):
+                # already have the protocol specified.
+                uri_conn = sqlite_file
+            else:
+                uri_conn = "sqlite:///{}".format(sqlite_file)
         else:
             uri_conn = "sqlite:///:memory:"
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -125,7 +125,6 @@ class TestBook_create_book(object):
             fk = insp.get_foreign_keys(tbl)
             assert len(fk) == 0
 
-
 class TestBook_open_book(object):
     def test_open_noarg(self):
         with pytest.raises(ValueError):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -54,3 +54,12 @@ class TestSession_create_book(object):
                          db_name="pqsd",
                          db_host="qsdqs",
                          db_port=3434) == "mysql+pymysql://foo:pp@qsdqs:3434/pqsd?charset=utf8"
+
+        ### Test duplicate protocol spec. This happens when the open_book is called
+        ### from GnuCash reports (.scm), gnucash-utilities.
+        sqlite_uri = "sqlite:///some_file"
+        uri = sqlite_uri
+        assert build_uri(sqlite_file=uri) == sqlite_uri
+        # When run with just the name (without sqlite:// prefix):
+        uri = "some_file"
+        assert build_uri(sqlite_file=uri) == sqlite_uri

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -58,7 +58,7 @@ class TestSession_create_book(object):
         ### Test duplicate protocol spec. This happens when the open_book is called
         ### from GnuCash reports (.scm), gnucash-utilities.
         sqlite_uri = "sqlite:///some_file"
-        uri = sqlite_uri
+        uri = "sqlite:///some_file"
         assert build_uri(sqlite_file=uri) == sqlite_uri
         # When run with just the name (without sqlite:// prefix):
         uri = "some_file"


### PR DESCRIPTION
Avoiding duplicate sqlite:/// in the connection string when used from the reports (gnucash-utilities).