### PR TITLE
Using quantity for get_balance

### DIFF
--- a/piecash/core/account.py
+++ b/piecash/core/account.py
@@ -251,7 +251,15 @@ class Account(DeclarativeBaseGuid):
         else:
             return u""
 
-    def get_balance(self):
+
+    def get_value(self):
+        """
+        Retrieves the value sum. 
+        For commodity accounts, this will display the value in the commodity currency.
+        """
+        return sum([sp.value for sp in self.splits]) * self.sign
+
+    def get_quantity(self):
         """
         Returns the balance of the account expressed in account's commodity/currency.
         If this is a stock/fund account, it will return the number of shares held.

--- a/piecash/core/account.py
+++ b/piecash/core/account.py
@@ -260,7 +260,7 @@ class Account(DeclarativeBaseGuid):
 
     def get_quantity(self):
         """
-        Returns the balance of the account expressed in commodity.
+        Returns the balance of the account expressed in account's commodity.
         If this is a stock/fund account, it will return the number of shares held.
         In case of a transfer split, this value will be in account's currency.
         """

--- a/piecash/core/account.py
+++ b/piecash/core/account.py
@@ -252,14 +252,7 @@ class Account(DeclarativeBaseGuid):
             return u""
 
 
-    def get_value(self):
-        """
-        Retrieves the value sum. 
-        For commodity accounts, this will display the value in the commodity currency.
-        """
-        return sum([sp.value for sp in self.splits]) * self.sign
-
-    def get_quantity(self):
+    def get_balance(self):
         """
         Returns the balance of the account expressed in account's commodity/currency.
         If this is a stock/fund account, it will return the number of shares held.

--- a/piecash/core/account.py
+++ b/piecash/core/account.py
@@ -253,18 +253,12 @@ class Account(DeclarativeBaseGuid):
 
     def get_balance(self):
         """
-        Returns the balance of the account.
-        In case of a transfer split, this value will be in remote currency.
-        """
-        return sum([sp.value for sp in self.splits]) * self.sign
-
-    def get_quantity(self):
-        """
-        Returns the balance of the account expressed in account's commodity.
+        Returns the balance of the account expressed in account's commodity/currency.
         If this is a stock/fund account, it will return the number of shares held.
-        In case of a transfer split, this value will be in account's currency.
+        If this is a currency account, it will be in account's currency.
         """
         return sum([sp.quantity for sp in self.splits]) * self.sign
+
 
     @property
     def sign(self):

--- a/piecash/core/account.py
+++ b/piecash/core/account.py
@@ -253,14 +253,16 @@ class Account(DeclarativeBaseGuid):
 
     def get_balance(self):
         """
-        Returns the balance of the account
+        Returns the balance of the account.
+        In case of a transfer split, this value will be in remote currency.
         """
         return sum([sp.value for sp in self.splits]) * self.sign
 
     def get_quantity(self):
         """
-        Returns the balance of the account expressed in commodity. 
+        Returns the balance of the account expressed in commodity.
         If this is a stock/fund account, it will return the number of shares held.
+        In case of a transfer split, this value will be in account's currency.
         """
         return sum([sp.quantity for sp in self.splits]) * self.sign
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -424,11 +424,9 @@ class TestBook_access_book(object):
                 continue
 
             balance = account.get_balance()
-            quantity = account.get_quantity()
 
-            print(account.fullname, balance, quantity)
-			#total_balance += balance
-            total_quantity += quantity
+            #print(account.fullname, balance)
+            total_balance += balance
 
 		#print("Balance:", total_balance)
-        assert total_quantity == Decimal(13)
+        assert total_balance == Decimal(13)

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -416,7 +416,7 @@ class TestBook_access_book(object):
         """
         security = book_investment.get(Commodity, mnemonic="VEUR")
 
-        total_quantity = Decimal(0)
+        total = Decimal(0)
 
         for account in security.accounts:
 			# exclude Trading accouns explicitly.
@@ -426,7 +426,7 @@ class TestBook_access_book(object):
             balance = account.get_balance()
 
             #print(account.fullname, balance)
-            total_balance += balance
+            total += balance
 
 		#print("Balance:", total_balance)
-        assert total_balance == Decimal(13)
+        assert total == Decimal(13)


### PR DESCRIPTION
adding more info to method descriptions, based on #45.
get_quantity() should be used in all normal circumstances.