### PR TITLE
DOC: Adapted error message

### DIFF
--- a/piecash/core/session.py
+++ b/piecash/core/session.py
@@ -342,7 +342,7 @@ def adapt_session(session, book, readonly):
     # add logic to make session readonly
     def readonly_commit(*args, **kwargs):
         # session.rollback()
-        raise GnucashException("You cannot change the DB, it is locked !")
+        raise GnucashException("You cannot change the DB, it was opened as readonly!")
 
     if readonly:
         session.commit = readonly_commit


### PR DESCRIPTION
Commiting to a readonly file is rejected because of readonly, not because of locked file.

The old message really irritated me several times.