### PR TITLE
Fix python version bindings per setuptools docs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,11 +7,7 @@ name = "pypi"
 
 [packages]
 
-"local-install" = {path = ".", extras = [ "pandas", "mysql", "postgres", "finance-quote"], editable = true}
-"local-install2" = {path = ".", extras = [ "mysql", "postgres", "finance-quote"], editable = true}
-"local-install3" = {path = ".", extras = [  "postgres", "finance-quote"], editable = true}
-"local-install4" = {path = ".", extras = [ "finance-quote"], editable = true}
-
+"local-install" = {path = ".", extras = ["test"], editable = true}
 
 
 [dev-packages]

--- a/setup.py
+++ b/setup.py
@@ -251,13 +251,13 @@ setup_dict = dict(
                          'pytz',
                          'tzlocal',
                          'click',
+                         'enum34;python_version<"3.4"',
+                         'pandas==0.21.0;python_version=="3.4"',  # no wheels for py34 beyond 0.21.0
+                         'pandas;python_version!="3.4"'
                      ] + python_version_specific_requires,
     extras_require={
         'postgres': ["psycopg2"],
         'mysql':["PyMySQL"],
-        ':python_version=="2.7"': ['enum34'],
-        'pandas:python_version=="3.4"': ['pandas==0.21.0'], # no wheels for py34 beyond 0.21.0
-        'pandas:python_version!="3.4"': ['pandas'], # no wheels for py34 beyond 0.21.0
         'finance-quote': ["requests"],
     },
     # Allow tests to be run with `python setup.py test'.

--- a/setup.py
+++ b/setup.py
@@ -211,6 +211,17 @@ python_version_specific_requires = []
 
 # See here for more options:
 # <http://pythonhosted.org/setuptools/setuptools.html>
+pandas_reqs = [    
+    'pandas==0.21.0;python_version=="3.4"',
+    'pandas;python_version!="3.4"'
+]
+
+test_reqs = [
+    'pytest',
+    'pytest-cov',
+    'py',
+    'tox'
+]
 
 setup_dict = dict(
     name=metadata.package,
@@ -252,19 +263,16 @@ setup_dict = dict(
                          'tzlocal',
                          'click',
                          'enum34;python_version<"3.4"',
-                         'pandas==0.21.0;python_version=="3.4"',  # no wheels for py34 beyond 0.21.0
-                         'pandas;python_version!="3.4"'
                      ] + python_version_specific_requires,
     extras_require={
         'postgres': ["psycopg2"],
         'mysql':["PyMySQL"],
         'finance-quote': ["requests"],
+        'pandas': pandas_reqs,
+        'test': ['psycopg2', 'PyMySQL', 'requests'] + pandas_reqs + test_reqs
     },
     # Allow tests to be run with `python setup.py test'.
-    tests_require=[
-        'pytest',
-        'py',
-    ],
+    tests_require=test_reqs
     entry_points={
         'console_scripts': [
             'piecash = piecash.scripts.export:cli',


### PR DESCRIPTION
- Fix python-specific dependency installation to use install_requires
rather than extras_requires per [setuptools
documentation](http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies)