### PR TITLE
create_stock_from_symbol() reference to 'exchangeTimezoneName'

### DIFF
--- a/piecash/yahoo_client.py
+++ b/piecash/yahoo_client.py
@@ -41,10 +41,10 @@ def get_latest_quote(symbol):
         data['longName'],
         data['symbol'],
         data['exchange'],
-        data['exchangeTimezoneShortName'],
+        data['exchangeTimezoneName'],
         data['currency'],
         datetime.datetime.fromtimestamp(data['regularMarketTime']).astimezone(
-            pytz.timezone(data['exchangeTimezoneShortName'])),
+            pytz.timezone(data['exchangeTimezoneName'])),
         data['regularMarketPrice'],
     )
 

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -74,8 +74,8 @@ class TestFactoriesCommodities(object):
         cdty = book_basic.commodities(mnemonic="AAPL")
 
         assert cdty.namespace == "NMS"
-        assert cdty.quote_tz == "EST"
-        assert cdty.quote_source == "yahoo"
+        assert cdty.quote_tz == "America/New_York"
+        assert cdty.quote_source == "yahoo_json"
         assert cdty.mnemonic == "AAPL"
         assert cdty.fullname == "Apple Inc."
 


### PR DESCRIPTION
Changed create_stock_from_symbol() to reference 'exchangeTimezoneName' as it is unambiguously recognized by pytz as opposed to the current 'exchangeTimezoneShortName', test suite also updated to reflect change