### PR TITLE
correct documentation for is_saved property

### DIFF
--- a/piecash/core/book.py
+++ b/piecash/core/book.py
@@ -280,7 +280,10 @@ class Book(DeclarativeBaseGuid):
 
     @property
     def is_saved(self):
-        """Save the changes to the file/DB (=commit transaction)
+        """Are all the changes saved to the file/DB?
+
+        You can check a session has changes (new, deleted, changed objects)
+        by getting the ``book.is_saved`` property.
         """
         return self.session.is_saved
 


### PR DESCRIPTION
book.is_saved was described in the class documentation but in the property documentation it was incorrectly copied from book.save(), creating confusion.