### PR TITLE
replace deprecated XML getchildren call with list

### DIFF
--- a/piecash/core/currency_ISO.py
+++ b/piecash/core/currency_ISO.py
@@ -1961,7 +1961,7 @@ The codes assigned for transactions where no currency is involved
 </CcyTbl>
 </ISO_4217>
 """
-ISO_currencies = {cur.findtext("Ccy"): ISO_type(*[e.text for e in cur.getchildren()])
+ISO_currencies = {cur.findtext("Ccy"): ISO_type(*[e.text for e in list(cur)])
                   for cur in ElementTree.fromstring(ISO_currencies_XML).findall(".//CcyNtry")
                   if cur.findtext("CcyMnrUnts")
                   }


### PR DESCRIPTION
This fixes [issue 147](https://github.com/sdementen/piecash/issues/147). A longer explanation is in the link, but the TL;DR is that python's standard lib module for XML deprecated the `getchildren` method for XML elements in python 3.9, [replacing it](https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren) with a call to the built-in `list` function.

I haven't written any tests for this, though I have manually tested it. I am banking on the hopes that a test already exists, since `create_currency_from_ISO` is not a new function I'm making, but rather an existing one.

I recursively grepped for other uses of `getchildren()` in the `piecash` package, but I didn't find any.

Let me know if there are any issues with this PR.