### PR TITLE
allow tag splits with zero quantity

### DIFF
--- a/piecash/core/transaction.py
+++ b/piecash/core/transaction.py
@@ -157,7 +157,7 @@ class Split(DeclarativeBaseGuid):
         self._quantity_denom_basis = self.account.commodity_scu
         self._value_denom_basis = self.transaction.currency.fraction
 
-        if self.transaction.currency != self.account.commodity:
+        if self.transaction.currency != self.account.commodity and self.quantity != 0:
             # let us also add a Price
             from piecash import Price
 

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -240,6 +240,24 @@ class TestTransaction_create_transaction(object):
         assert d["cur"] == 0
         assert all([v == Decimal(0) for k, v in d.items() if k != "cur"])
 
+    def test_tag_split_zero_quantity(self, book_transactions):
+        broker = book_transactions.accounts(name="broker")
+        asset = book_transactions.accounts.get(name="asset")
+        inc = book_transactions.accounts.get(name="inc")
+        currency = book_transactions.default_currency
+
+        value = Decimal(250)
+        splits = [
+            Split(asset, value),
+            Split(inc, -value),
+            Split(broker, value=0, quantity=0),  # tag split for assigning dividend income to stock
+        ]
+
+        Transaction(currency, description='Dividend income', splits=splits)
+
+        book_transactions.validate()
+
+
 
 class TestTransaction_lots(object):
     def test_create_simpletlot_addsplits(self, book_basic):


### PR DESCRIPTION
This commit allows adding empty splits that merely "tag" an account, without transferring any value. This can be useful e.g. for associating dividends to stock accounts. 