### PR TITLE
Allow for quantity=0 for negative values too.

### DIFF
--- a/piecash/core/transaction.py
+++ b/piecash/core/transaction.py
@@ -150,8 +150,8 @@ class Split(DeclarativeBaseGuid):
             if self.quantity is None:
                 raise GncValidationError(
                     "The split quantity is not defined while the split is on a commodity different from the transaction")
-            if (self.quantity.is_signed() != self.value.is_signed() and
-                self.value != 0 and self.quantity != 0):
+            # Allow for either value to be 0.0 (or -0.0).
+            if self.quantity * self.value < 0:
                 raise GncValidationError("The split quantity has not the same sign as the split value")
 
         # everything is fine, let us normalise the value with respect to the currency/commodity precisions

--- a/piecash/core/transaction.py
+++ b/piecash/core/transaction.py
@@ -150,7 +150,8 @@ class Split(DeclarativeBaseGuid):
             if self.quantity is None:
                 raise GncValidationError(
                     "The split quantity is not defined while the split is on a commodity different from the transaction")
-            if self.quantity.is_signed() != self.value.is_signed():
+            if (self.quantity.is_signed() != self.value.is_signed() and
+                self.value != 0 and self.quantity != 0):
                 raise GncValidationError("The split quantity has not the same sign as the split value")
 
         # everything is fine, let us normalise the value with respect to the currency/commodity precisions

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -257,6 +257,62 @@ class TestTransaction_create_transaction(object):
 
         book_transactions.validate()
 
+    def test_tag_split_zero_quantity_with_value(self, book_transactions):
+        broker = book_transactions.accounts(name="broker")
+        inc = book_transactions.accounts.get(name="inc")
+        value = Decimal(250)
+
+        # Transaction recording capital gains.
+        splits = [
+            Split(broker, value, quantity=0),
+            Split(inc, -value),
+        ]
+        Transaction(inc.commodity, description='Capital gains', splits=splits)
+        book_transactions.validate()
+
+        # Transaction recording capital loss.
+        splits = [
+            Split(broker, -value, quantity=0),
+            Split(inc, value),
+        ]
+        Transaction(inc.commodity, description='Capital loss', splits=splits)
+        book_transactions.validate()
+
+        # Do the same tests with a -0.0 quantity. This Decimal has is_signed=True.
+        mzero = Decimal('-0.00')
+
+        # Transaction recording capital gains.
+        splits = [
+            Split(broker, value, quantity=mzero),
+            Split(inc, -value),
+        ]
+        Transaction(inc.commodity, description='Capital gains', splits=splits)
+        book_transactions.validate()
+
+        # Transaction recording capital loss.
+        splits = [
+            Split(broker, -value, quantity=mzero),
+            Split(inc, value),
+        ]
+        Transaction(inc.commodity, description='Capital loss', splits=splits)
+        book_transactions.validate()
+
+    def test_tag_split_zero_value(self, book_transactions):
+        broker = book_transactions.accounts(name="broker")
+        asset = book_transactions.accounts.get(name="asset")
+        currency = book_transactions.default_currency
+
+        # Give away 250 shares for free.
+        quantity = Decimal(-250)
+        splits = [
+            Split(asset, 0),
+            Split(broker, 0, quantity=quantity),
+        ]
+
+        Transaction(currency, description='donation', splits=splits)
+
+        book_transactions.validate()
+
 
 
 class TestTransaction_lots(object):


### PR DESCRIPTION
When a Split has either quantity=0 or value=0, don't validate their signs. While
Decimal does distinguish between +0 and -0, piecash does not preserve that
information, and it doesn't make much sense to assign significance to the sign
of a zero anyway.

A Split with quantity=0 and value<0 can appear when shares are sold with a loss.

A Split with quantity<0 and value=0 represents giving shares away for free.