### PR TITLE
Ledger export: fix truncation of prices

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 What's new
 ==========
 
+Version 1.1.5 (2021-03-21)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- fix ledger export truncation of prices (fix #158)
+- fix ledger export to order transactions by date (fix #159)
+
 Version 1.1.4 (2021-01-29)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ click = "*"
 
 
 [dev-packages]
-money = "*"
+babel = "*"
 tox-pipenv = "*"
 psycopg2 = "*"
 pymysql = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -336,13 +336,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
-        "money": {
-            "hashes": [
-                "sha256:ac049caf19df9502f7a481d5959fc51b038baaa68c5dcef2070ffbb785729f7d"
-            ],
-            "index": "pypi",
-            "version": "==1.3.0"
-        },
         "numpy": {
             "hashes": [
                 "sha256:04c7d4ebc5ff93d9822075ddb1751ff392a4375e5885299445fcebf877f179d5",

--- a/piecash/ledger.py
+++ b/piecash/ledger.py
@@ -13,9 +13,11 @@ from .core import Transaction, Account, Commodity, Price, Book
 """
 
 try:
-    from money import Money
+    import babel
+    import babel.numbers
+    BABEL_AVAILABLE = True
 except ImportError:
-    Money = None
+    BABEL_AVAILABLE = False
 
 
 @singledispatch
@@ -43,27 +45,30 @@ def format_commodity(mnemonic, locale):
     return NUMBER_RE.sub("", s)
 
 
-def format_currency(amount, decimals, currency, locale=False):
-    if locale:
-        if locale is True:
-            locale = getdefaultlocale()[0]
-        if Money is None:
+def format_currency(amount, decimals, currency, locale=False, decimal_quantization=True):
+    if locale is True:
+        locale = getdefaultlocale()[0]
+        if BABEL_AVAILABLE is False:
             raise ValueError(
-                f"You must install Money ('pip install money') to export to ledger in your locale '{locale}'"
+                f"You must install babel ('pip install babel') to export to ledger in your locale '{locale}'"
             )
-        return Money(amount=amount, currency=currency).format(locale)
-    else:
-        if Money:
-            try:
-                # version from Money
-                return str(Money(amount=amount, currency=currency))
-            except ValueError:
-                # local hand made version
-                return "{:.{}f} {}".format(amount, decimals, format_commodity(currency, locale))
         else:
-            # local hand made version
-            return "{:.{}f} {}".format(amount, decimals, currency)
-
+            return babel.numbers.format_currency(
+                amount,
+                currency,
+                format=None,
+                locale=locale,
+                currency_digits=True,
+                format_type='standard',
+                decimal_quantization=decimal_quantization
+            )
+    else:
+        # local hand made version
+        if decimal_quantization:
+            digits = decimals
+        else:
+            digits = max(decimals, len((str(amount)+'.').split('.')[1].rstrip('0')))
+        return "{} {:,.{}f}".format(currency, amount, digits)
 
 @ledger.register(Transaction)
 def _(tr, locale=False, **kwargs):
@@ -91,7 +96,8 @@ def _(tr, locale=False, **kwargs):
                         split.quantity,
                         split.account.commodity.precision,
                         split.account.commodity.mnemonic,
-                        locale=False,
+                        locale,
+                        decimal_quantization=False
                     ),
                     amount=format_currency(
                         abs(split.value), tr.currency.precision, tr.currency.mnemonic, locale
@@ -149,7 +155,13 @@ def _(price, locale=False, **kwargs):
     return "P {:%Y-%m-%d %H:%M:%S} {} {}\n".format(
         price.date,
         format_commodity(price.commodity.mnemonic, locale),
-        format_currency(price.value, price.currency.precision, price.currency.mnemonic, locale),
+        format_currency(
+            price.value,
+            price.currency.precision,
+            price.currency.mnemonic,
+            locale,
+            decimal_quantization=False
+        )
     )
 
 

--- a/piecash/metadata.py
+++ b/piecash/metadata.py
@@ -8,7 +8,7 @@ Information describing the project.
 package = 'piecash'
 project = "Python interface to GnuCash documents"
 project_no_spaces = project.replace(' ', '')
-version = '1.1.4'
+version = '1.1.5'
 description = 'A pythonic interface to GnuCash SQL documents.'
 authors = ['sdementen']
 authors_string = ', '.join(authors)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,6 @@ ipython-genutils==0.2.0
 jedi==0.17.2
 Jinja2==2.11.2
 MarkupSafe==1.1.1
-money==1.3.0
 numpy==1.19.2
 packaging==20.4
 pandas==1.1.3

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ install_requires = ["SQLAlchemy>=1.0, <1.4", "SQLAlchemy-Utils!=0.36.8", "pytz",
 extras_require = {
     "postgres": ["psycopg2"],
     "mysql": ["PyMySQL"],
-    "ledger": ["money", "babel"],
+    "ledger": ["babel"],
     "pandas": ["pandas"],
     "qif": ["qifparse"],
     "yahoo": ["requests"],

--- a/tests/references/file_template_full.commodity_notes_True.ledger
+++ b/tests/references/file_template_full.commodity_notes_True.ledger
@@ -72,7 +72,7 @@ account Mouvements:CURRENCY:EUR5
 
 P 2018-02-21 00:00:00 FOO AED 0.90
 P 2018-02-21 00:00:00 USD EUR 1.40
-P 2018-02-21 00:00:00 EUR AED 1.11
+P 2018-02-21 00:00:00 EUR AED 1.111111111111111111111111111
 P 2018-02-21 00:00:00 ADF AED 1.50
 
 2014-12-24 income 1
@@ -113,9 +113,9 @@ P 2018-02-21 00:00:00 ADF AED 1.50
 	Asset:Fixed:House                         EUR 20,000.00
 
 2018-02-21 buy foo
-	Mouvements:NASDAQ:FOO                     FOO -130.00 @@ EUR 1,200.00
+	Mouvements:NASDAQ:FOO                     FOO -130.0000 @@ EUR 1,200.00
 	Asset:Current:Savings                     EUR -1,200.00
-	Asset:Broker:Foo stock                    FOO 130.00 @@ EUR 1,200.00
+	Asset:Broker:Foo stock                    FOO 130.0000 @@ EUR 1,200.00
 	Mouvements:CURRENCY:EUR5                  EUR 1,200.00
 
 2018-02-21 Opening Balance

--- a/tests/references/file_template_full.ledger
+++ b/tests/references/file_template_full.ledger
@@ -67,7 +67,7 @@ account Mouvements:CURRENCY:EUR5
 
 P 2018-02-21 00:00:00 FOO AED 0.90
 P 2018-02-21 00:00:00 USD EUR 1.40
-P 2018-02-21 00:00:00 EUR AED 1.11
+P 2018-02-21 00:00:00 EUR AED 1.111111111111111111111111111
 P 2018-02-21 00:00:00 ADF AED 1.50
 
 2014-12-24 income 1
@@ -108,9 +108,9 @@ P 2018-02-21 00:00:00 ADF AED 1.50
 	Asset:Fixed:House                         EUR 20,000.00
 
 2018-02-21 buy foo
-	Mouvements:NASDAQ:FOO                     FOO -130.00 @@ EUR 1,200.00
+	Mouvements:NASDAQ:FOO                     FOO -130.0000 @@ EUR 1,200.00
 	Asset:Current:Savings                     EUR -1,200.00
-	Asset:Broker:Foo stock                    FOO 130.00 @@ EUR 1,200.00
+	Asset:Broker:Foo stock                    FOO 130.0000 @@ EUR 1,200.00
 	Mouvements:CURRENCY:EUR5                  EUR 1,200.00
 
 2018-02-21 Opening Balance

--- a/tests/references/file_template_full.locale_True.ledger
+++ b/tests/references/file_template_full.locale_True.ledger
@@ -67,7 +67,7 @@ account Mouvements:CURRENCY:EUR5
 
 P 2018-02-21 00:00:00  FOO 0,90 AED
 P 2018-02-21 00:00:00  $US 1,40 €
-P 2018-02-21 00:00:00  € 1,11 AED
+P 2018-02-21 00:00:00  € 1,111111111111111111111111111 AED
 P 2018-02-21 00:00:00  ADF 1,50 AED
 
 2014-12-24 income 1
@@ -108,9 +108,9 @@ P 2018-02-21 00:00:00  ADF 1,50 AED
 	Asset:Fixed:House                         20 000,00 €
 
 2018-02-21 buy foo
-	Mouvements:NASDAQ:FOO                     FOO -130.00 @@ 1 200,00 €
+	Mouvements:NASDAQ:FOO                     -130,00 FOO @@ 1 200,00 €
 	Asset:Current:Savings                     -1 200,00 €
-	Asset:Broker:Foo stock                    FOO 130.00 @@ 1 200,00 €
+	Asset:Broker:Foo stock                    130,00 FOO @@ 1 200,00 €
 	Mouvements:CURRENCY:EUR5                  1 200,00 €
 
 2018-02-21 Opening Balance

--- a/tests/references/file_template_full.short_account_names_True.ledger
+++ b/tests/references/file_template_full.short_account_names_True.ledger
@@ -67,7 +67,7 @@ account EUR5
 
 P 2018-02-21 00:00:00 FOO AED 0.90
 P 2018-02-21 00:00:00 USD EUR 1.40
-P 2018-02-21 00:00:00 EUR AED 1.11
+P 2018-02-21 00:00:00 EUR AED 1.111111111111111111111111111
 P 2018-02-21 00:00:00 ADF AED 1.50
 
 2014-12-24 income 1
@@ -108,9 +108,9 @@ P 2018-02-21 00:00:00 ADF AED 1.50
 	Asset:Fixed:House                         EUR 20,000.00
 
 2018-02-21 buy foo
-	Mouvements:NASDAQ:FOO                     FOO -130.00 @@ EUR 1,200.00
+	Mouvements:NASDAQ:FOO                     FOO -130.0000 @@ EUR 1,200.00
 	Asset:Current:Savings                     EUR -1,200.00
-	Asset:Broker:Foo stock                    FOO 130.00 @@ EUR 1,200.00
+	Asset:Broker:Foo stock                    FOO 130.0000 @@ EUR 1,200.00
 	Mouvements:CURRENCY:EUR5                  EUR 1,200.00
 
 2018-02-21 Opening Balance


### PR DESCRIPTION
Fixes https://github.com/sdementen/piecash/issues/158.

The CHANGELOG update covers both this and https://github.com/sdementen/piecash/pull/159.

To get this to work for localized output, I switched from [Money](https://github.com/carlospalol/money) to [Babel](http://babel.pocoo.org/en/latest/). Money uses Babel itself, and for our needs Babel was already doing most of the work. Using Babel directly makes it possible to avoid truncation by using the `decimal_quantization=False` option of [`babel.numbers.format_currency()`](http://babel.pocoo.org/en/latest/api/numbers.html#babel.numbers.format_currency).

Existing tests cover these changes. The differences can be seen in the `tests/references/*.ledger` files.

Prices are no longer truncated:
```diff
 P 2018-02-21 00:00:00 FOO AED 0.90
 P 2018-02-21 00:00:00 USD EUR 1.40
-P 2018-02-21 00:00:00 EUR AED 1.11
+P 2018-02-21 00:00:00 EUR AED 1.111111111111111111111111111
 P 2018-02-21 00:00:00 ADF AED 1.50
```
Including when `locale=True`:
```diff
 P 2018-02-21 00:00:00  FOO 0,90 AED
 P 2018-02-21 00:00:00  $US 1,40 €
-P 2018-02-21 00:00:00  € 1,11 AED
+P 2018-02-21 00:00:00  € 1,111111111111111111111111111 AED
 P 2018-02-21 00:00:00  ADF 1,50 AED
```

Another difference is that the `FOO` commodity is now rendered with 4 decimal places, matching its definition in the GnuCash database, at least for `locale=False`:
```diff
 2018-02-21 buy foo
-	Mouvements:NASDAQ:FOO                     FOO -130.00 @@ EUR 1,200.00
+	Mouvements:NASDAQ:FOO                     FOO -130.0000 @@ EUR 1,200.00
 	Asset:Current:Savings                     EUR -1,200.00
-	Asset:Broker:Foo stock                    FOO 130.00 @@ EUR 1,200.00
+	Asset:Broker:Foo stock                    FOO 130.0000 @@ EUR 1,200.00
 	Mouvements:CURRENCY:EUR5                  EUR 1,200.00
```

For `locale=True`, it's a bit more complicated. Previously, the commodity formatting forced non-localization, which meant that the decimal separator would be `.` even if `,` was used in the localized amount of the same split. I matched localization of commodities with the global setting to avoid this. For commoditities unknown to the localization library, like `FOO`, it will default to 2 decimal places, but I'm also using the `decimal_quantization=False` option, so if there are more significant digits they will be shown (this example has no additional signficant digits):
```diff
 2018-02-21 buy foo
-	Mouvements:NASDAQ:FOO                     FOO -130.00 @@ 1 200,00 €
+	Mouvements:NASDAQ:FOO                     -130,00 FOO @@ 1 200,00 €
 	Asset:Current:Savings                     -1 200,00 €
-	Asset:Broker:Foo stock                    FOO 130.00 @@ 1 200,00 €
+	Asset:Broker:Foo stock                    130,00 FOO @@ 1 200,00 €
 	Mouvements:CURRENCY:EUR5                  1 200,00 €
```

---

There is one remaining issue with localized output. A space is used as the thousands separator where localization rules require it, even though that's [not supported by ledger](https://github.com/ledger/ledger/issues/1916). However, it is supported by hledger and I think that's a lesser and separate issue from what's being handled in this PR.