### PR TITLE
Allow non-currency transaction

### DIFF
--- a/piecash/core/transaction.py
+++ b/piecash/core/transaction.py
@@ -314,11 +314,6 @@ class Transaction(DeclarativeBaseGuid):
         if old["STATE_CHANGES"][-1] == "deleted":
             return
 
-        if self.currency.namespace != "CURRENCY":
-            raise GncValidationError(
-                "You are assigning a non currency commodity to a transaction"
-            )
-
         # check all accounts related to the splits of the transaction are not placeholder(=frozen)
         for sp in self.splits:
             if sp.account.placeholder != 0:


### PR DESCRIPTION
Currency validation was introduced in 1b2b7907f304ccca982502227cb0be912c799951,
but gnucash doesn't enforce that.

This can allow us redistribute stocks and asset between accounts.