### PR TITLE
Fix ability to get to TXN from Invoice (and Lot)

### DIFF
--- a/piecash/business/invoice.py
+++ b/piecash/business/invoice.py
@@ -134,9 +134,9 @@ class Invoice(DeclarativeBaseGuid):
     #                                                      })
     term_guid = Column("terms", VARCHAR(length=32), ForeignKey("billterms.guid"))
     billing_id = Column("billing_id", VARCHAR(length=2048))
-    post_txn_guid = Column("post_txn", VARCHAR(length=32), ForeignKey("lots.guid"))
+    post_txn_guid = Column("post_txn", VARCHAR(length=32), ForeignKey("transactions.guid"))
     post_lot_guid = Column(
-        "post_lot", VARCHAR(length=32), ForeignKey("transactions.guid")
+        "post_lot", VARCHAR(length=32), ForeignKey("lots.guid")
     )
     post_acc_guid = Column("post_acc", VARCHAR(length=32), ForeignKey("accounts.guid"))
     billto_type = Column("billto_type", INTEGER())


### PR DESCRIPTION
No invoice had a link to its TXN, but the field post_txn_guid was filled and verifiable by filtering `book.transactions` for that guid. 

Very likely this fixes the same problem but for 'Lot' Many2one as well, but I don't have data like that.

--- 

If you made it this far... I'm not a sqlalchemy or GNUCash expert, but it very much appears that the `invoices` table does double duty and represents what the column `entries.bill` would be a GUID for (i.e. `Entry.bill` would be a Many2one char field filled with a GUID that points to an `Invoice` by its GUID).

My use case is to extract GNUCash to an 'other' accounting platform and am currently doing some sqlite3 updates to just put it in the invoice field `UPDATE entries SET invoice = bill;`.

I'd guess that bill could become a @property that returns the correct Invoice on the Entry side, but I wouldn't hazard a guess how to make `Invoice.entries` work on the reverse... maybe be an @property that checks returns different sets based on a field on the Invoice itself?