### PR TITLE
Minimal changes requried to support sqlalchemy 1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -202,7 +202,7 @@ def _lint():
 
 ## package dependencies
 install_requires = [
-    "SQLAlchemy>=1.0, <1.4",
+    "SQLAlchemy>=1.0, <1.5",
     "SQLAlchemy-Utils!=0.36.8",
     "pytz",
     "tzlocal",


### PR DESCRIPTION
Hopefully this PR is better constructed than the last one and gets merged :-). Fixes #165 

sqlalchemy 1.4 changed the implementation of `as_declarative` relative to previous versions. The new implementation fails to handle the `constructor` keyword the same way as earlier versions. This commit reimplements `as_declarative` so that the constructor keyword works as expected in SA 1.4 (and newer).

The only other change is to expand the allowed range of sqlalchemy versions in `setup.py`.

I've tested this locally under the following configurations, all tests pass:

* Python 3.7, SQLAlchemy 1.2.19
* Python 3.8, SQLAlchemy 1.3.24
* Python 3.9, SQLAlchemy 1.3.24
* Python 3.10, SQLAlchemy 1.4.51
* Python 3.11, SQLAlchemy 1.4.51