### PR TITLE
 Improve conversion logic for zero balances

### DIFF
--- a/piecash/core/account.py
+++ b/piecash/core/account.py
@@ -329,7 +329,7 @@ class Account(DeclarativeBaseGuid):
                 ]
             )
 
-        if commodity != self.commodity:
+        if balance and commodity != self.commodity:
             try:
                 # conversion is done directly from self.commodity to commodity (if possible)
                 factor = self.commodity.currency_conversion(commodity)


### PR DESCRIPTION
This change ensures that currency conversion is only attempted if the balance is non-zero. In some cases, currency conversion is impossible due to the absence of a price for the required currency pair. However, this does not matter if the balance is zero, so the conversion can be skipped in such cases.