### PR TITLE
Make PieCash compatible with SQLALchemy 2.0

### DIFF
--- a/piecash/_declbase.py
+++ b/piecash/_declbase.py
@@ -2,7 +2,7 @@ import uuid
 
 from sqlalchemy import Column, VARCHAR, event
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import relation, foreign, object_session
+from sqlalchemy.orm import relationship, foreign, object_session
 
 from ._common import CallableList
 from .kvp import DictWrapper, Slot
@@ -23,7 +23,7 @@ class DeclarativeBaseGuid(DictWrapper, DeclarativeBase):
 
     @declared_attr
     def slots(cls):
-        rel = relation(
+        rel = relationship(
             "Slot",
             primaryjoin=foreign(Slot.obj_guid) == cls.guid,
             cascade="all, delete-orphan",

--- a/piecash/budget.py
+++ b/piecash/budget.py
@@ -3,7 +3,7 @@ from __future__ import division
 import uuid
 
 from sqlalchemy import Column, VARCHAR, INTEGER, BIGINT, ForeignKey
-from sqlalchemy.orm import relation, foreign
+from sqlalchemy.orm import relationship, foreign
 
 from ._common import hybrid_property_gncnumeric, Recurrence, CallableList
 from ._declbase import DeclarativeBaseGuid
@@ -38,14 +38,14 @@ class Budget(DeclarativeBaseGuid):
     num_periods = Column("num_periods", INTEGER(), nullable=False)
 
     # # relation definitions
-    recurrence = relation(
+    recurrence = relationship(
         Recurrence,
         primaryjoin=foreign(Recurrence.obj_guid) == guid,
         cascade="all, delete-orphan",
         uselist=False,
     )
 
-    amounts = relation(
+    amounts = relationship(
         "BudgetAmount",
         back_populates="budget",
         cascade="all, delete-orphan",
@@ -86,8 +86,8 @@ class BudgetAmount(DeclarativeBase):
     amount = hybrid_property_gncnumeric(_amount_num, _amount_denom)
 
     # relation definitions
-    account = relation("Account", back_populates="budget_amounts")
-    budget = relation("Budget", back_populates="amounts")
+    account = relationship("Account", back_populates="budget_amounts")
+    budget = relationship("Budget", back_populates="amounts")
 
     def __str__(self):
         return "BudgetAmount<{}={}>".format(self.period_num, self.amount)

--- a/piecash/business/invoice.py
+++ b/piecash/business/invoice.py
@@ -1,7 +1,7 @@
 import uuid
 
 from sqlalchemy import Column, INTEGER, BIGINT, VARCHAR, ForeignKey
-from sqlalchemy.orm import composite, relation
+from sqlalchemy.orm import composite, relationship
 
 from .person import PersonType
 
@@ -41,13 +41,13 @@ class Billterm(DeclarativeBaseGuid):
     cutoff = Column("cutoff", INTEGER())
 
     # relation definitions
-    children = relation(
+    children = relationship(
         "Billterm",
         back_populates="parent",
         cascade="all, delete-orphan",
         collection_class=CallableList,
     )
-    parent = relation(
+    parent = relationship(
         "Billterm",
         back_populates="children",
         remote_side=guid,
@@ -104,8 +104,8 @@ class Entry(DeclarativeBaseGuid):
     order_guid = Column("order_guid", VARCHAR(length=32), ForeignKey("orders.guid"))
 
     # relation definitions
-    order = relation("Order", back_populates="entries")
-    invoice = relation("Invoice", back_populates="entries")
+    order = relationship("Order", back_populates="entries")
+    invoice = relationship("Invoice", back_populates="entries")
 
     def __str__(self):
         return "Entry<{}>".format(self.description)
@@ -147,13 +147,13 @@ class Invoice(DeclarativeBaseGuid):
 
     # relation definitions
     # todo: check all relations and understanding of types...
-    term = relation("Billterm")
-    currency = relation("Commodity")
-    post_account = relation("Account")
-    post_lot = relation("Lot")
-    post_txn = relation("Transaction")
+    term = relationship("Billterm")
+    currency = relationship("Commodity")
+    post_account = relationship("Account")
+    post_lot = relationship("Lot")
+    post_txn = relationship("Transaction")
 
-    entries = relation(
+    entries = relationship(
         "Entry",
         back_populates="invoice",
         cascade="all, delete-orphan",
@@ -225,7 +225,7 @@ class Order(DeclarativeBaseGuid):
 
     # relation definitions
     # todo: owner_guid/type links to Vendor or Customer
-    entries = relation(
+    entries = relationship(
         "Entry",
         back_populates="order",
         cascade="all, delete-orphan",

--- a/piecash/business/person.py
+++ b/piecash/business/person.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 from sqlalchemy import Column, VARCHAR, INTEGER, BIGINT, ForeignKey, and_, event
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import composite, relation, foreign
+from sqlalchemy.orm import composite, relationship, foreign
 
 from .._common import hybrid_property_gncnumeric, CallableList
 from .._declbase import DeclarativeBaseGuid
@@ -113,7 +113,7 @@ class Person:
 
     @declared_attr
     def currency(cls):
-        return relation("Commodity")
+        return relationship("Commodity")
 
     # hold the name of the counter to use for id
     _counter_name = None
@@ -149,7 +149,7 @@ class Person:
 
         owner_type = PersonType.get(cls, None)
         if owner_type and not hasattr(cls, "jobs"):
-            cls.jobs = relation('Job',
+            cls.jobs = relationship('Job',
                 primaryjoin=and_(
                     cls.guid == foreign(Job.owner_guid),
                     owner_type == Job.owner_type,
@@ -226,8 +226,8 @@ class Customer(Person, DeclarativeBaseGuid):
     taxtable_guid = Column("taxtable", VARCHAR(length=32), ForeignKey("taxtables.guid"))
 
     # relation definitions
-    taxtable = relation("Taxtable")
-    term = relation("Billterm")
+    taxtable = relationship("Taxtable")
+    term = relationship("Billterm")
 
     def __init__(
         self,
@@ -307,7 +307,7 @@ class Employee(Person, DeclarativeBaseGuid):
     rate = hybrid_property_gncnumeric(_rate_num, _rate_denom)
 
     # relation definitions
-    creditcard_account = relation("Account")
+    creditcard_account = relationship("Account")
 
     def __init__(
         self,
@@ -384,8 +384,8 @@ class Vendor(Person, DeclarativeBaseGuid):
     )
 
     # relation definitions
-    taxtable = relation("Taxtable")
-    term = relation("Billterm")
+    taxtable = relationship("Taxtable")
+    term = relationship("Billterm")
 
     def __init__(
         self,

--- a/piecash/business/tax.py
+++ b/piecash/business/tax.py
@@ -1,6 +1,6 @@
 import uuid
 from sqlalchemy import Column, VARCHAR, BIGINT, INTEGER, ForeignKey
-from sqlalchemy.orm import relation
+from sqlalchemy.orm import relationship
 
 from .._common import hybrid_property_gncnumeric, CallableList
 from .._declbase import DeclarativeBaseGuid, DeclarativeBase
@@ -26,19 +26,19 @@ class Taxtable(DeclarativeBaseGuid):
     parent_guid = Column("parent", VARCHAR(length=32), ForeignKey("taxtables.guid"))
 
     # relation definitions
-    entries = relation(
+    entries = relationship(
         "TaxtableEntry",
         back_populates="taxtable",
         cascade="all, delete-orphan",
         collection_class=CallableList,
     )
-    children = relation(
+    children = relationship(
         "Taxtable",
         back_populates="parent",
         cascade="all, delete-orphan",
         collection_class=CallableList,
     )
-    parent = relation(
+    parent = relationship(
         "Taxtable",
         back_populates="children",
         remote_side=guid,
@@ -79,8 +79,8 @@ class TaxtableEntry(DeclarativeBase):
     type = Column("type", ChoiceType({1: "value", 2: "percentage"}), nullable=False)
 
     # relation definitions
-    taxtable = relation("Taxtable", back_populates="entries")
-    account = relation("Account")
+    taxtable = relationship("Taxtable", back_populates="entries")
+    account = relationship("Account")
 
     def __init__(self, type, amount, account, taxtable=None):
         self.type = type

--- a/piecash/core/account.py
+++ b/piecash/core/account.py
@@ -4,7 +4,7 @@ import uuid
 from enum import Enum
 
 from sqlalchemy import Column, VARCHAR, ForeignKey, INTEGER
-from sqlalchemy.orm import relation, validates
+from sqlalchemy.orm import relationship, validates
 
 from .._common import CallableList, GncConversionError
 from .._declbase import DeclarativeBaseGuid
@@ -165,37 +165,37 @@ class Account(DeclarativeBaseGuid):
     )
 
     # relation definitions
-    commodity = relation("Commodity", back_populates="accounts")
-    children = relation(
+    commodity = relationship("Commodity", back_populates="accounts")
+    children = relationship(
         "Account",
         back_populates="parent",
         cascade="all, delete-orphan",
         collection_class=CallableList,
     )
-    parent = relation(
+    parent = relationship(
         "Account",
         back_populates="children",
         remote_side=guid,
     )
-    splits = relation(
+    splits = relationship(
         "Split",
         back_populates="account",
         cascade="all, delete-orphan",
         collection_class=CallableList,
     )
-    lots = relation(
+    lots = relationship(
         "Lot",
         back_populates="account",
         cascade="all, delete-orphan",
         collection_class=CallableList,
     )
-    budget_amounts = relation(
+    budget_amounts = relationship(
         "BudgetAmount",
         back_populates="account",
         cascade="all, delete-orphan",
         collection_class=CallableList,
     )
-    scheduled_transaction = relation(
+    scheduled_transaction = relationship(
         "ScheduledTransaction",
         back_populates="template_account",
         cascade="all, delete-orphan",

--- a/piecash/core/book.py
+++ b/piecash/core/book.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from operator import attrgetter
 
 from sqlalchemy import Column, VARCHAR, ForeignKey, inspect
-from sqlalchemy.orm import relation, aliased, joinedload
+from sqlalchemy.orm import relationship, aliased, joinedload
 from sqlalchemy.orm.base import instance_state
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -99,12 +99,12 @@ class Book(DeclarativeBaseGuid):
     )
 
     # relation definitions
-    root_account = relation(
+    root_account = relationship(
         "Account",
         # back_populates='root_book',
         foreign_keys=[root_account_guid],
     )
-    root_template = relation("Account", foreign_keys=[root_template_guid])
+    root_template = relationship("Account", foreign_keys=[root_template_guid])
 
     uri = None
     session = None

--- a/piecash/core/commodity.py
+++ b/piecash/core/commodity.py
@@ -9,8 +9,8 @@ import datetime
 from decimal import Decimal
 
 from sqlalchemy import Column, VARCHAR, INTEGER, ForeignKey, BIGINT, Index
-from sqlalchemy.orm import relation
-from sqlalchemy.orm.exc import MultipleResultsFound
+from sqlalchemy.orm import relationship, object_session
+from sqlalchemy.exc import MultipleResultsFound
 
 from ._commodity_helper import quandl_fx
 from .._common import CallableList, GncConversionError
@@ -67,18 +67,21 @@ class Price(DeclarativeBaseGuid):
     value = hybrid_property_gncnumeric(_value_num, _value_denom)
 
     # relation definitions
-    commodity = relation(
+    commodity = relationship(
         "Commodity",
         back_populates="prices",
         foreign_keys=[commodity_guid],
     )
-    currency = relation(
+    currency = relationship(
         "Commodity",
         foreign_keys=[currency_guid],
     )
 
     def __init__(self, commodity, currency, date, value, type="unknown", source="user:price"):
         self.commodity = commodity
+        session = object_session(commodity) if commodity else None
+        if session is not None:
+            session.add(self)
         self.currency = currency
         assert _type(date) is datetime.date
         self.date = date
@@ -174,19 +177,19 @@ class Commodity(DeclarativeBaseGuid):
                 )
 
     # relation definitions
-    accounts = relation(
+    accounts = relationship(
         "Account",
         back_populates="commodity",
         cascade="all, delete-orphan",
         collection_class=CallableList,
     )
-    transactions = relation(
+    transactions = relationship(
         "Transaction",
         back_populates="currency",
         cascade="all, delete-orphan",
         collection_class=CallableList,
     )
-    prices = relation(
+    prices = relationship(
         "Price",
         back_populates="commodity",
         foreign_keys=[Price.commodity_guid],

--- a/piecash/core/commodity.py
+++ b/piecash/core/commodity.py
@@ -79,9 +79,8 @@ class Price(DeclarativeBaseGuid):
 
     def __init__(self, commodity, currency, date, value, type="unknown", source="user:price"):
         self.commodity = commodity
-        session = object_session(commodity) if commodity else None
-        if session is not None:
-            session.add(self)
+        if commodity.book is not None:
+            commodity.book.add(self)
         self.currency = currency
         assert _type(date) is datetime.date
         self.date = date

--- a/piecash/core/session.py
+++ b/piecash/core/session.py
@@ -490,8 +490,7 @@ def adapt_session(session, book, readonly):
     def delete_lock():
         session.execute(
             gnclock.delete().where(
-                (gnclock.c.hostname == socket.gethostname())
-                and (gnclock.c.pid == os.getpid())
+                (gnclock.c.hostname == socket.gethostname()) & (gnclock.c.pid == os.getpid())
             )
         )
         session.commit()

--- a/piecash/core/session.py
+++ b/piecash/core/session.py
@@ -489,8 +489,8 @@ def adapt_session(session, book, readonly):
     # add logic to create/delete GnuCash locks
     def delete_lock():
         session.execute(
-            gnclock.delete(
-                whereclause=(gnclock.c.hostname == socket.gethostname())
+            gnclock.delete().where(
+                (gnclock.c.hostname == socket.gethostname())
                 and (gnclock.c.pid == os.getpid())
             )
         )
@@ -500,7 +500,7 @@ def adapt_session(session, book, readonly):
 
     def create_lock():
         session.execute(
-            gnclock.insert(values=dict(hostname=socket.gethostname(), pid=os.getpid()))
+            gnclock.insert().values(hostname=socket.gethostname(), pid=os.getpid())
         )
         session.commit()
 

--- a/piecash/core/session.py
+++ b/piecash/core/session.py
@@ -315,7 +315,7 @@ def create_book(
     # create all (tables, fk, ...)
     DeclarativeBase.metadata.create_all(engine)
 
-    s = Session(bind=engine)
+    s = Session(bind=engine, future=True)
 
     # create all rows in version table
     assert (
@@ -428,34 +428,35 @@ def open_book(
 
         shutil.copyfile(url, url_backup)
 
-    locks = list(engine.execute(gnclock.select()))
+    with engine.connect() as connection:
+        locks = list(connection.execute(gnclock.select()))
 
-    # ensure the file is not locked by GnuCash itself
-    if locks and not open_if_lock:
-        raise GnucashException("Lock on the file")
+        # ensure the file is not locked by GnuCash itself
+        if locks and not open_if_lock:
+            raise GnucashException("Lock on the file")
 
-    s = Session(bind=engine)
+        s = Session(bind=engine, future=True)
 
-    # check the versions in the table versions is consistent with the API
-    version_book = {
-        v.table_name: v.table_version
-        for v in s.query(Version).all()
-        if "Gnucash" not in v.table_name
-    }
-    for version, vt in version_supported.items():
-        if version_book == {k: v for k, v in vt.items() if "Gnucash" not in k}:
-            break
-    else:
-        raise ValueError("Unsupported table versions")
-    assert version == "3.0" or version == "3.7" or version == "4.1", (
-        "This version of piecash only support books from gnucash (3.0|3.7|4.1) "
-        "which is not the case for {}".format(uri_conn)
-    )
+        # check the versions in the table versions is consistent with the API
+        version_book = {
+            v.table_name: v.table_version
+            for v in s.query(Version).all()
+            if "Gnucash" not in v.table_name
+        }
+        for version, vt in version_supported.items():
+            if version_book == {k: v for k, v in vt.items() if "Gnucash" not in k}:
+                break
+        else:
+            raise ValueError("Unsupported table versions")
+        assert version == "3.0" or version == "3.7" or version == "4.1", (
+            "This version of piecash only support books from gnucash (3.0|3.7|4.1) "
+            "which is not the case for {}".format(uri_conn)
+        )
 
-    book = s.query(Book).one()
-    adapt_session(s, book=book, readonly=readonly)
+        book = s.query(Book).one()
+        adapt_session(s, book=book, readonly=readonly)
 
-    return book
+        return book
 
 
 def adapt_session(session, book, readonly):

--- a/piecash/core/transaction.py
+++ b/piecash/core/transaction.py
@@ -102,6 +102,8 @@ class Split(DeclarativeBaseGuid):
     ):
         self.transaction = transaction
         self.account = account
+        if account is not None:
+            account.book.add(self)
         self.value = value
         self.quantity = value if quantity is None else quantity
         self.memo = memo
@@ -109,6 +111,8 @@ class Split(DeclarativeBaseGuid):
         self.reconcile_date = reconcile_date
         self.reconcile_state = reconcile_state
         self.lot = lot
+        if self.transaction is not None and self.transaction.book is None:
+            self.book.add(self.transaction)
 
     def __str__(self):
         try:

--- a/piecash/core/transaction.py
+++ b/piecash/core/transaction.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from decimal import Decimal
 
 from sqlalchemy import Column, VARCHAR, ForeignKey, BIGINT, INTEGER, Index
-from sqlalchemy.orm import relation, validates, foreign
+from sqlalchemy.orm import relationship, validates, foreign, object_session
 from sqlalchemy.orm.base import NEVER_SET
 
 from .._common import CallableList, GncImbalanceError
@@ -74,9 +74,9 @@ class Split(DeclarativeBaseGuid):
     lot_guid = Column("lot_guid", VARCHAR(length=32), ForeignKey("lots.guid"))
 
     # relation definitions
-    account = relation("Account", back_populates="splits")
-    lot = relation("Lot", back_populates="splits")
-    transaction = relation(
+    account = relationship("Account", back_populates="splits")
+    lot = relationship("Lot", back_populates="splits")
+    transaction = relationship(
         "Transaction", back_populates="splits", cascade="refresh-expire"
     )
 
@@ -258,11 +258,11 @@ class Transaction(DeclarativeBaseGuid):
     )
 
     # relation definitions
-    currency = relation(
+    currency = relationship(
         "Commodity",
         back_populates="transactions",
     )
-    splits = relation(
+    splits = relationship(
         "Split",
         back_populates="transaction",
         cascade="all, delete-orphan",
@@ -296,6 +296,12 @@ class Transaction(DeclarativeBaseGuid):
             self.notes = notes
         if splits:
             self.splits = splits
+            # Ensure transaction is added to session if splits have accounts in a session
+            for split in splits:
+                session = object_session(split.account) if split.account else None
+                if session is not None:
+                    session.add(self)
+                    break
 
     def __str__(self):
         return "Transaction<[{}] '{}' on {:%Y-%m-%d}{}>".format(
@@ -464,8 +470,8 @@ class ScheduledTransaction(DeclarativeBaseGuid):
     )
 
     # relation definitions
-    template_account = relation("Account")
-    recurrence = relation(
+    template_account = relationship("Account")
+    recurrence = relationship(
         "Recurrence",
         primaryjoin=guid == foreign(Recurrence.obj_guid),
         cascade="all, delete-orphan",
@@ -501,11 +507,11 @@ class Lot(DeclarativeBaseGuid):
     notes = pure_slot_property("notes")
 
     # relation definitions
-    account = relation(
+    account = relationship(
         "Account",
         back_populates="lots",
     )
-    splits = relation(
+    splits = relationship(
         "Split",
         back_populates="lot",
         collection_class=CallableList,

--- a/piecash/core/transaction.py
+++ b/piecash/core/transaction.py
@@ -298,9 +298,9 @@ class Transaction(DeclarativeBaseGuid):
             self.splits = splits
             # Ensure transaction is added to session if splits have accounts in a session
             for split in splits:
-                session = object_session(split.account) if split.account else None
-                if session is not None:
-                    session.add(self)
+                book = split.account.book
+                if book is not None:
+                    book.add(self)
                     break
 
     def __str__(self):

--- a/piecash/kvp.py
+++ b/piecash/kvp.py
@@ -6,7 +6,7 @@ from enum import Enum
 from importlib import import_module
 
 from sqlalchemy import Column, VARCHAR, INTEGER, REAL, BIGINT, types, event, Index
-from sqlalchemy.orm import relation, foreign, object_session, backref
+from sqlalchemy.orm import relationship, foreign, object_session, backref
 
 from ._common import CallableList
 from ._common import hybrid_property_gncnumeric
@@ -267,7 +267,7 @@ class SlotFrame(DictWrapper, Slot):
 
     guid_val = Column("guid_val", VARCHAR(length=32))
 
-    slots = relation(
+    slots = relationship(
         "Slot",
         primaryjoin=foreign(Slot.obj_guid) == guid_val,
         cascade="all, delete-orphan",

--- a/piecash/sa_extra.py
+++ b/piecash/sa_extra.py
@@ -47,7 +47,7 @@ try:
             kw.pop("constructor", _declarative_constructor),
         )
 
-        return registry(_bind=bind, metadata=metadata, class_registry=class_registry, constructor=constructor).as_declarative_base(**kw)
+        return registry(metadata=metadata, class_registry=class_registry, constructor=constructor).as_declarative_base(**kw)
 
 except ImportError:
     # `as_declarative` was under `sqlalchemy.ext.declarative` prior to 1.4

--- a/tests/references/file_template_full.locale_True.ledger
+++ b/tests/references/file_template_full.locale_True.ledger
@@ -6,7 +6,7 @@ commodity €
 
 commodity FOO
 
-commodity US$
+commodity $
 
 account Asset
 	check commodity == "€"
@@ -62,7 +62,7 @@ account Mouvements:CURRENCY:EUR5
 	check commodity == "€"
 
 P 2018-02-21 00:00:00 FOO 0,90 AED
-P 2018-02-21 00:00:00 US$ 1,40 €
+P 2018-02-21 00:00:00 $ 1,40 €
 P 2018-02-21 00:00:00 € 1,111111111111111111111111111 AED
 P 2018-02-21 00:00:00 ADF 1,50 AED
 

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -143,8 +143,10 @@ class TestBook_create_book(object):
         insp = Inspector.from_engine(create_engine(db_sqlite_uri))
         fk_total = []
         for tbl in insp.get_table_names():
+            if tbl.startswith('sqlite_'):
+                continue
             fk_total.append(insp.get_foreign_keys(tbl))
-        assert len(fk_total) == 25
+        assert len(fk_total) == 24
 
     def test_create_without_FK(self):
         # create without FK

--- a/tests/test_model_common.py
+++ b/tests/test_model_common.py
@@ -4,7 +4,7 @@ import datetime
 
 import pytest
 import pytz
-from sqlalchemy import create_engine, Column, TEXT
+from sqlalchemy import create_engine, Column, TEXT, text
 from sqlalchemy.orm import sessionmaker, composite
 
 import piecash._common as mc
@@ -17,8 +17,7 @@ def session():
     engine = create_engine("sqlite://")
 
     metadata = mc.DeclarativeBase.metadata
-    metadata.bind = engine
-    metadata.create_all()
+    metadata.create_all(bind=engine)
 
     s = sessionmaker(bind=engine)()
 
@@ -82,7 +81,7 @@ class TestModelCommon(object):
         s.flush()
         assert a.day
 
-        assert str(list(s.bind.execute("select day from c_table"))[0][0]) == "20100412"
+        assert str(list(s.execute(text("select day from c_table")))[0][0]) == "20100412"
 
     def test_datetime(self):
         class D(DeclarativeBaseGuid):
@@ -99,7 +98,7 @@ class TestModelCommon(object):
         assert a.time
 
         assert (
-            str(list(s.bind.execute("select time from d_table"))[0][0])
+            str(list(s.execute(text("select time from d_table")))[0][0])
             == "2010-04-12 03:04:05"
         )
 


### PR DESCRIPTION
This PR contains a minimal set of changes to migrate piecash to SQLAlchemy 2.x:

- all tests pass when run with SqlAlchemy 1.4 and SqlAlchemy 2.0.44
